### PR TITLE
Add develop branch to CI triggers

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -2,14 +2,19 @@ name: Helm CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
     paths:
       - 'helm/**'
       - 'gitops/**'
+      - 'tests/**'
+      - '.github/workflows/helm-ci.yml'
   pull_request:
+    branches: [main, develop]
     paths:
       - 'helm/**'
       - 'gitops/**'
+      - 'tests/**'
+      - '.github/workflows/helm-ci.yml'
 
 jobs:
   helm-lint:

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -2,8 +2,9 @@ name: Integration Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
+    branches: [main, develop]
 
 jobs:
   integration:


### PR DESCRIPTION
## Summary
- helm-ci and integration-test workflows now trigger on pushes to `develop` and PRs targeting `develop`
- Added `tests/**` and workflow self-trigger paths to helm-ci

Required for gitflow branching model where feature branches merge to develop, develop merges to main.