### PR TITLE
fix: pin nebula-pq image to 1.11.0-pq.1, clean up Renovate config

### DIFF
--- a/helm/disentangle/values.yaml
+++ b/helm/disentangle/values.yaml
@@ -95,7 +95,7 @@ nebula:
   enabled: false
   image:
     repository: ghcr.io/disentangle-network/nebula-pq
-    tag: "latest"
+    tag: "1.11.0-pq.1"
     pullPolicy: IfNotPresent
   # Mode: "lighthouse" or "node"
   mode: "node"

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "packageRules": [
     {
       "matchManagers": ["helm-values"],
-      "matchPackagePatterns": ["disentangle.*"],
+      "matchPackagePatterns": ["disentangle.*", "nebula.*"],
       "automerge": false,
       "labels": ["disentangle-update"]
     },
@@ -16,19 +16,15 @@
       "labels": ["helm-deps"]
     },
     {
-      "matchManagers": ["dockerfile"],
-      "matchPackagePatterns": ["rust"],
-      "groupName": "rust-toolchain",
-      "automerge": true,
-      "matchUpdateTypes": ["minor", "patch"]
-    },
-    {
       "matchManagers": ["github-actions"],
       "automerge": true,
       "matchUpdateTypes": ["minor", "patch"],
       "labels": ["ci-update"]
     }
   ],
+  "helm-values": {
+    "fileMatch": ["helm/.+/values\\.yaml$"]
+  },
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"]


### PR DESCRIPTION
## Summary

- Pin `nebula.image.tag` from `latest` to `1.11.0-pq.1` in `helm/disentangle/values.yaml` to prevent silent image drift on pod restarts
- Remove dead `dockerfile`/`rust-toolchain` rule from `renovate.json` (no Dockerfiles in this repo)
- Add `helm-values.fileMatch` pattern so Renovate's `helm-values` manager explicitly tracks `helm/*/values.yaml` for container image tag updates

## Test plan

- [ ] `helm lint helm/disentangle/` passes (0 failures confirmed locally)
- [ ] All 5 golden file regression tests pass (`tests/golden/verify.sh` confirmed locally)
- [ ] Renovate dry-run against updated config shows nebula-pq tracked under `helm-values` manager