### PR TITLE
ci: add security scan to PR gate, align helm-unittest versions

### DIFF
--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -93,7 +93,7 @@ jobs:
         with:
           version: v3.14.0
       - name: Install helm-unittest
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.6.3
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v0.5.2
       - name: Run unit tests
         run: helm unittest helm/disentangle/
 
@@ -120,3 +120,21 @@ jobs:
             tar xz -C /usr/local/bin
       - name: Run OPA policy tests
         run: ./tests/policies/run-conftest.sh
+
+  security:
+    name: Security Scan
+    runs-on: ubuntu-latest
+    needs: helm-template
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+      - name: Install kube-linter
+        run: |
+          curl -sL https://github.com/stackrox/kube-linter/releases/download/v0.6.8/kube-linter-linux.tar.gz | \
+            tar xz -C /usr/local/bin
+      - name: Render templates
+        run: helm template test-release helm/disentangle/ > /tmp/rendered.yaml
+      - name: Run kube-linter
+        run: kube-linter lint --config .kube-linter.yaml /tmp/rendered.yaml

--- a/helm/disentangle/templates/tests/test-connection.yaml
+++ b/helm/disentangle/templates/tests/test-connection.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "kube-linter.io/ignore-all": "true"
 spec:
   restartPolicy: Never
   containers:

--- a/helm/disentangle/templates/tests/test-genesis-sync.yaml
+++ b/helm/disentangle/templates/tests/test-genesis-sync.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "kube-linter.io/ignore-all": "true"
 spec:
   restartPolicy: Never
   containers:

--- a/helm/disentangle/templates/tests/test-rpc-api.yaml
+++ b/helm/disentangle/templates/tests/test-rpc-api.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "kube-linter.io/ignore-all": "true"
 spec:
   restartPolicy: Never
   containers:


### PR DESCRIPTION
## Summary

- Adds a blocking `security` job to `helm-ci.yml` that runs kube-linter v0.6.8 on rendered templates using the existing `.kube-linter.yaml` config
- Adds `kube-linter.io/ignore-all: "true"` annotation to the three helm test hook Pods so one-shot pods don't trigger checks intended for long-running workloads (this is the canonical kube-linter mechanism, replacing `|| true` in the nightly)
- Aligns helm-unittest from v0.6.3 (CI) to v0.5.2 (nightly) -- v0.5.2 was pinned in the nightly to avoid a `platformHooks` incompatibility with Helm 3.14.0

## Test plan

- [ ] `helm lint helm/disentangle/` passes locally (verified: 0 chart(s) failed)
- [ ] `security` job runs and passes in CI on this PR
- [ ] `helm-unittest` job runs with v0.5.2 and passes
- [ ] nightly helm-unittest and CI helm-unittest now use the same plugin version