### PR TITLE
fix: regenerate golden files for chart 0.2.0

### DIFF
--- a/tests/golden/custom-resources.yaml
+++ b/tests/golden/custom-resources.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 6
@@ -23,10 +23,10 @@ kind: ServiceAccount
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: disentangle/templates/configmap.yaml
@@ -35,10 +35,10 @@ kind: ConfigMap
 metadata:
   name: golden-test-disentangle-config
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-config.yaml: |
@@ -64,10 +64,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-headless
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -91,10 +91,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -113,10 +113,10 @@ kind: StatefulSet
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: golden-test-disentangle-headless
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: disentangle-node
-        image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+        image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -217,10 +217,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-connection
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -297,10 +297,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-genesis
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -385,10 +385,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/tests/golden/default.yaml
+++ b/tests/golden/default.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 3
@@ -23,10 +23,10 @@ kind: ServiceAccount
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: disentangle/templates/configmap.yaml
@@ -35,10 +35,10 @@ kind: ConfigMap
 metadata:
   name: golden-test-disentangle-config
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-config.yaml: |
@@ -64,10 +64,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-headless
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -91,10 +91,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -113,10 +113,10 @@ kind: StatefulSet
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: golden-test-disentangle-headless
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: disentangle-node
-        image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+        image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -217,10 +217,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-connection
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -297,10 +297,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-genesis
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -385,10 +385,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/tests/golden/full-features.yaml
+++ b/tests/golden/full-features.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 4
@@ -23,10 +23,10 @@ kind: ServiceAccount
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: disentangle/templates/configmap.yaml
@@ -35,10 +35,10 @@ kind: ConfigMap
 metadata:
   name: golden-test-disentangle-config
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-config.yaml: |
@@ -64,10 +64,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-headless
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -91,10 +91,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: LoadBalancer
@@ -113,10 +113,10 @@ kind: StatefulSet
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: golden-test-disentangle-headless
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: disentangle-node
-        image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+        image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -217,10 +217,10 @@ kind: CronJob
 metadata:
   name: golden-test-disentangle-txgen
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/component: txgen
 spec:
@@ -308,10 +308,10 @@ kind: Ingress
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   ingressClassName: nginx
@@ -333,10 +333,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-connection
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -413,10 +413,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-genesis
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -501,10 +501,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/tests/golden/minimal.yaml
+++ b/tests/golden/minimal.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 2
@@ -23,10 +23,10 @@ kind: ServiceAccount
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: disentangle/templates/configmap.yaml
@@ -35,10 +35,10 @@ kind: ConfigMap
 metadata:
   name: golden-test-disentangle-config
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-config.yaml: |
@@ -64,10 +64,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-headless
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -91,10 +91,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -113,10 +113,10 @@ kind: StatefulSet
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: golden-test-disentangle-headless
@@ -138,7 +138,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: disentangle-node
-        image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+        image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -211,10 +211,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-connection
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -291,10 +291,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-genesis
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -379,10 +379,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test

--- a/tests/golden/no-serviceaccount.yaml
+++ b/tests/golden/no-serviceaccount.yaml
@@ -5,10 +5,10 @@ kind: PodDisruptionBudget
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   minAvailable: 3
@@ -23,10 +23,10 @@ kind: ConfigMap
 metadata:
   name: golden-test-disentangle-config
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 data:
   cluster-config.yaml: |
@@ -52,10 +52,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-headless
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -79,10 +79,10 @@ kind: Service
 metadata:
   name: golden-test-disentangle-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -101,10 +101,10 @@ kind: StatefulSet
 metadata:
   name: golden-test-disentangle
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: golden-test-disentangle-headless
@@ -126,7 +126,7 @@ spec:
           type: RuntimeDefault
       containers:
       - name: disentangle-node
-        image: ghcr.io/disentangle-network/disentangle-node:v0.4.0
+        image: ghcr.io/disentangle-network/disentangle-node:v0.4.1
         imagePullPolicy: IfNotPresent
         securityContext:
           allowPrivilegeEscalation: false
@@ -205,10 +205,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-connection
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -285,10 +285,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-genesis
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test
@@ -373,10 +373,10 @@ kind: Pod
 metadata:
   name: golden-test-disentangle-test-rpc
   labels:
-    helm.sh/chart: disentangle-0.1.0
+    helm.sh/chart: disentangle-0.2.0
     app.kubernetes.io/name: disentangle
     app.kubernetes.io/instance: golden-test
-    app.kubernetes.io/version: "v0.4.0"
+    app.kubernetes.io/version: "v0.4.1"
     app.kubernetes.io/managed-by: Helm
   annotations:
     "helm.sh/hook": test


### PR DESCRIPTION
## Summary
- Regenerated all 5 golden test files (`default`, `minimal`, `full-features`, `no-serviceaccount`, `custom-resources`) to match chart version 0.2.0 / appVersion v0.4.1
- Golden files were stale after commit e61858f bumped versions, causing nightly regression CI to fail for 5 days
- Changes are purely version string updates: `disentangle-0.1.0` -> `disentangle-0.2.0`, `v0.4.0` -> `v0.4.1`, and the container image tag

## Test plan
- [x] Ran `tests/golden/verify.sh` locally -- all 5 golden file tests pass
- [ ] Nightly CI should pass after merge