### PR TITLE
ci: add CD workflow for automated OKE deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,97 @@
+name: Deploy to OKE
+
+on:
+  workflow_run:
+    workflows: ["Integration Test"]
+    types: [completed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy to OKE
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.0
+
+      - name: Install OCI CLI
+        run: |
+          pip install oci-cli --quiet
+
+      - name: Configure OCI credentials
+        run: |
+          mkdir -p ~/.oci
+          cat > ~/.oci/config <<OCIEOF
+          [DEFAULT]
+          tenancy=${{ secrets.OCI_CLI_TENANCY }}
+          user=${{ secrets.OCI_CLI_USER }}
+          fingerprint=${{ secrets.OCI_CLI_FINGERPRINT }}
+          key_file=~/.oci/key.pem
+          region=${{ secrets.OCI_CLI_REGION }}
+          OCIEOF
+          echo "${{ secrets.OCI_CLI_KEY_CONTENT }}" > ~/.oci/key.pem
+          chmod 600 ~/.oci/key.pem ~/.oci/config
+
+      - name: Generate kubeconfig
+        run: |
+          mkdir -p ~/.kube
+          oci ce cluster create-kubeconfig \
+            --cluster-id ${{ secrets.OKE_CLUSTER_OCID }} \
+            --region ${{ secrets.OCI_CLI_REGION }} \
+            --file ~/.kube/config \
+            --token-version 2.0.0 \
+            --kube-endpoint PUBLIC_ENDPOINT
+          chmod 600 ~/.kube/config
+
+      - name: Verify cluster access
+        run: |
+          kubectl cluster-info
+          kubectl get nodes
+
+      - name: Deploy with Helm
+        run: |
+          helm upgrade --install disentangle helm/disentangle/ \
+            --namespace disentangle \
+            --set nodes.count=3 \
+            --set persistence.enabled=true \
+            --set persistence.storageClass=oci-bv \
+            --set persistence.size=1Gi \
+            --set pow.difficulty=16 \
+            --set pow.mineIntervalSecs=10 \
+            --wait --timeout=300s
+
+      - name: Verify deployment
+        run: |
+          kubectl get pods -n disentangle -o wide
+          kubectl get svc -n disentangle
+
+      - name: Run Helm tests
+        run: |
+          helm test disentangle -n disentangle --timeout=120s
+
+      - name: Collect diagnostics on failure
+        if: failure()
+        run: |
+          echo "=== Pod Status ==="
+          kubectl get pods -n disentangle -o wide
+          echo ""
+          echo "=== Pod Events ==="
+          kubectl get events -n disentangle --sort-by='.lastTimestamp' | tail -30
+          echo ""
+          echo "=== Pod Logs ==="
+          for pod in $(kubectl get pods -n disentangle -o name 2>/dev/null | head -3); do
+            echo "--- $pod ---"
+            kubectl logs "$pod" -n disentangle --tail=20 2>/dev/null || echo "No logs"
+          done


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` for continuous deployment to the live OKE cluster
- Triggers automatically after Integration Test workflow succeeds on main
- Uses OCI CLI for ephemeral kubeconfig token generation (no static credentials)
- Includes post-deploy verification (kubectl status + helm test)
- Collects diagnostics on failure for debugging

## Prerequisites (before this can function)
The following GitHub secrets must be provisioned on the deploy repo:
- `OCI_CLI_TENANCY` — OCI tenancy OCID
- `OCI_CLI_USER` — OCI user/service-principal OCID
- `OCI_CLI_FINGERPRINT` — API key fingerprint
- `OCI_CLI_KEY_CONTENT` — Private key PEM content
- `OCI_CLI_REGION` — Region (us-phoenix-1)
- `OKE_CLUSTER_OCID` — OKE cluster OCID

Optionally, configure a GitHub environment called `production` with required reviewers for manual approval gate.

## Safety
- Only deploys after integration tests pass (workflow_run trigger)
- `--wait --timeout=300s` ensures Helm reports deployment health
- Helm test suite runs post-deploy
- Failure diagnostics collected automatically
- Helm revision history enables `helm rollback` if needed

## Test plan
- [ ] Verify workflow YAML is valid (lint)
- [ ] Provision secrets on repo
- [ ] Merge and verify workflow triggers after next Integration Test pass
- [ ] Confirm helm upgrade succeeds on live cluster
- [ ] Confirm helm tests pass post-deploy